### PR TITLE
Preserve z coordinates in geometries

### DIFF
--- a/core/src/main/java/geodb/GeoDB.java
+++ b/core/src/main/java/geodb/GeoDB.java
@@ -47,7 +47,7 @@ public class GeoDB {
     static {
         boolean pre = false;
         try {
-            new WKBWriter(2, true);
+            new WKBWriter(3, true);
         }
         catch(NoSuchMethodError e) {
             //means they are using an older verison of jts, fallback to old constructor
@@ -58,7 +58,7 @@ public class GeoDB {
     }
 
     static final WKBWriter wkbwriter() {
-        return PRE_JTS12 ? new WKBWriter(2) : new WKBWriter(2, true);
+        return PRE_JTS12 ? new WKBWriter(3) : new WKBWriter(3, true);
     }
     
     static final WKBReader wkbreader() {

--- a/core/src/test/java/geodb/GeoDB3DTest.java
+++ b/core/src/test/java/geodb/GeoDB3DTest.java
@@ -1,0 +1,26 @@
+package geodb;
+
+import junit.framework.Assert;
+import geodb.GeoDB;
+
+import org.junit.Test;
+
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.ParseException;
+import com.vividsolutions.jts.io.WKTReader;
+
+public class GeoDB3DTest {
+
+    @Test
+    public void test3dPreservation() throws ParseException {
+        Geometry g = new WKTReader().read("POINT (10 10 -5)");
+        g.setSRID(4326);
+
+        // to and from ewkb
+        byte[] ewkb = GeoDB.gToEWKB(g);
+        Geometry gFromEwkb = GeoDB.gFromEWKB(ewkb);
+        Assert.assertTrue(g.equalsExact(gFromEwkb));
+        Assert.assertEquals(4326, gFromEwkb.getSRID());
+        Assert.assertEquals(g.getCoordinate().z, gFromEwkb.getCoordinate().z);
+    }
+}


### PR DESCRIPTION
Hi Justin, here's very simple patch with very simple test case to preserve the z coordinate when writing geometries to WKB. All the tests pass with these changes. Not sure if z coordinates were intentionally disabled, but if not could you consider merging this?
